### PR TITLE
More updates from Dag Lem

### DIFF
--- a/jni/VICEPlugin/vice/c64/cart/c64carthooks.c
+++ b/jni/VICEPlugin/vice/c64/cart/c64carthooks.c
@@ -235,7 +235,7 @@ static const cmdline_option_t cmdline_options[] =
       NULL, NULL },
     { "-cartdep64", CALL_FUNCTION, 1,
       cart_attach_cmdline, (void *)CARTRIDGE_DELA_EP64, NULL, NULL,
-      USE_PARAM_ID, USE_DESCRIPTION_STRING,
+      USE_PARAM_ID, USE_DESCRIPTION_ID,
       IDCLS_P_NAME, IDCLS_ATTACH_RAW_DELA_EP64_CART,
       NULL, NULL },
     { "-cartdep7x8", CALL_FUNCTION, 1,
@@ -296,12 +296,12 @@ static const cmdline_option_t cmdline_options[] =
       NULL, NULL },
     { "-cartff", CALL_FUNCTION, 1,
       cart_attach_cmdline, (void *)CARTRIDGE_FREEZE_FRAME, NULL, NULL,
-      USE_PARAM_ID, USE_DESCRIPTION_STRING,
+      USE_PARAM_ID, USE_DESCRIPTION_ID,
       IDCLS_P_NAME, IDCLS_ATTACH_RAW_FREEZE_FRAME_CART,
       NULL, NULL },
     { "-cartfm", CALL_FUNCTION, 1,
       cart_attach_cmdline, (void *)CARTRIDGE_FREEZE_MACHINE, NULL, NULL,
-      USE_PARAM_ID, USE_DESCRIPTION_STRING,
+      USE_PARAM_ID, USE_DESCRIPTION_ID,
       IDCLS_P_NAME, IDCLS_ATTACH_RAW_FREEZE_MACHINE_CART,
       NULL, NULL },
     { "-cartfp", CALL_FUNCTION, 1,
@@ -441,7 +441,7 @@ static const cmdline_option_t cmdline_options[] =
       NULL, NULL },
     { "-cartsimon", CALL_FUNCTION, 1,
       cart_attach_cmdline, (void *)CARTRIDGE_SIMONS_BASIC, NULL, NULL,
-      USE_PARAM_ID, USE_DESCRIPTION_STRING,
+      USE_PARAM_ID, USE_DESCRIPTION_ID,
       IDCLS_P_NAME, IDCLS_ATTACH_RAW_SIMONS_BASIC_CART,
       NULL, NULL },
     { "-cartss4", CALL_FUNCTION, 1,
@@ -481,6 +481,7 @@ int cart_cmdline_options_init(void)
 {
         /* "Slot 0" */
     if (mmc64_cmdline_options_init() < 0
+        || tpi_cmdline_options_init() < 0
         /* "Slot 1" */
         || dqbb_cmdline_options_init() < 0
         || expert_cmdline_options_init() < 0

--- a/jni/VICEPlugin/vice/c64/cart/c64tpi.c
+++ b/jni/VICEPlugin/vice/c64/cart/c64tpi.c
@@ -40,6 +40,7 @@
 #include "c64io.h"
 #include "c64mem.h"
 #include "cartridge.h"
+#include "cmdline.h"
 #include "drivecpu.h"
 #include "lib.h"
 #include "log.h"
@@ -48,6 +49,7 @@
 #include "monitor.h"
 #include "resources.h"
 #include "tpi.h"
+#include "translate.h"
 #include "types.h"
 #include "util.h"
 
@@ -525,6 +527,33 @@ void tpi_resources_shutdown(void)
 {
     lib_free(ieee488_filename);
     ieee488_filename = NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+
+static const cmdline_option_t cmdline_options[] =
+{
+    { "-ieee488", SET_RESOURCE, 0,
+      NULL, NULL, "IEEE488", (resource_value_t)1,
+      USE_PARAM_STRING, USE_DESCRIPTION_STRING,
+      IDCLS_UNUSED, IDCLS_UNUSED,
+      NULL, T_("enable IEEE488 interface") },
+    { "+ieee488", SET_RESOURCE, 0,
+      NULL, NULL, "IEEE488", (resource_value_t)0,
+      USE_PARAM_STRING, USE_DESCRIPTION_STRING,
+      IDCLS_UNUSED, IDCLS_UNUSED,
+      NULL, T_("disable IEEE488 interface") },
+    { "-ieee488image", SET_RESOURCE, 1,
+      NULL, NULL, "IEEE488Image", NULL,
+      USE_PARAM_ID, USE_DESCRIPTION_STRING,
+      IDCLS_P_NAME, IDCLS_UNUSED,
+      NULL, T_("specify IEEE488 interface image name") },
+    { NULL }
+};
+
+int tpi_cmdline_options_init(void)
+{
+    return cmdline_register_options(cmdline_options);
 }
 
 /* ---------------------------------------------------------------------*/

--- a/jni/VICEPlugin/vice/c64/cart/c64tpi.h
+++ b/jni/VICEPlugin/vice/c64/cart/c64tpi.h
@@ -46,6 +46,7 @@ extern void tpi_config_setup(BYTE *rawcart);
 extern void tpi_detach(void);
 extern int tpi_enable(void);
 
+extern int tpi_cmdline_options_init(void);
 extern int tpi_resources_init(void);
 extern void tpi_resources_shutdown(void);
 

--- a/jni/VICEPlugin/vice/c64/cart/reu.c
+++ b/jni/VICEPlugin/vice/c64/cart/reu.c
@@ -508,6 +508,7 @@ static const resource_int_t resources_int[] = {
       &reu_write_image, set_reu_image_write, NULL },
     { "REUsize", 512, RES_EVENT_NO, NULL,
       &reu_size_kb, set_reu_size, NULL },
+    /* FIXME: kill this one with fire */
     { "REUfirstUnusedRegister", REU_REG_RW_UNUSED, RES_EVENT_NO, NULL,
       (int *) &rec_options.first_unused_register_address, set_reu_first_unused, NULL },
     /* keeping "enable" resource last prevents unnecessary (re)init when loading config file */

--- a/jni/VICEPlugin/vice/core/ciacore.c
+++ b/jni/VICEPlugin/vice/core/ciacore.c
@@ -189,7 +189,7 @@ static void cia_do_set_int(cia_context_t *cia_context, CLOCK rclk)
     if ((cia_context->model == CIA_MODEL_6526X)
      && (cia_context->rdi == rclk - 1)
      && (cia_context->irq_line != IK_NMI)) {
-        /* timer B bug */
+        /* FIXME explanation */
         return;
     }
 

--- a/jni/VICEPlugin/vice/info.c
+++ b/jni/VICEPlugin/vice/info.c
@@ -1244,5 +1244,5 @@ const char info_contrib_text[] =
 "\n"
 "Last but not least, a very special thanks to Andreas Arens, Lutz\n"
 "Sammer, Edgar Tornig, Christian Bauer, Wolfgang Lorenz, Miha\n"
-"Peternel and Per Håkan Sundell for writing cool emulators to\n"
-"compete with.  :-)\n\n";
+"Peternel, Per Håkan Sundell and David Horrocks for writing cool\n"
+"emulators to compete with.  :-)\n\n";

--- a/jni/VICEPlugin/vice/mouse.c
+++ b/jni/VICEPlugin/vice/mouse.c
@@ -435,26 +435,24 @@ static BYTE mouse_get_paddle_y(void)
 
 static BYTE mouse_get_paddle_x(void)
 {
-    int i = (input_port << 1);
-
-    if (input_port != 0) {
-        if (input_port & mouse_port) {
-            paddle_val[i] = mouse_paddle_update(paddle_val[i], &(paddle_old[i]), mousedrv_get_x());
-            return 0xff - paddle_val[i];
-        }
+    int i = input_port & mouse_port;
+    if (i != 0) {
+        i = i << 1;
+        /* one of the ports is selected */
+        paddle_val[i] = mouse_paddle_update(paddle_val[i], &(paddle_old[i]), mousedrv_get_x());
+        return 0xff - paddle_val[i];
     }
     return 0xff;
 }
 
 static BYTE mouse_get_paddle_y(void)
 {
-    int i = (input_port << 1) + 1;
-
-    if (input_port != 0) {
-        if (input_port & mouse_port) {
-            paddle_val[i] = mouse_paddle_update(paddle_val[i], &(paddle_old[i]), mousedrv_get_y());
-            return 0xff - paddle_val[i];
-        }
+    int i = input_port & mouse_port;
+    if (i != 0) {
+        i = (i << 1) + 1;
+        /* one of the ports is selected */
+        paddle_val[i] = mouse_paddle_update(paddle_val[i], &(paddle_old[i]), mousedrv_get_y());
+        return 0xff - paddle_val[i];
     }
     return 0xff;
 }

--- a/jni/VICEPlugin/vice/resid/filter.cc
+++ b/jni/VICEPlugin/vice/resid/filter.cc
@@ -308,7 +308,7 @@ Filter::Filter()
       // Create lookup table mapping capacitor voltage to op-amp input voltage:
       // vc -> vx
       for (int m = 0; m < fi.opamp_voltage_size; m++) {
-	scaled_voltage[m][0] = (N19*(fi.opamp_voltage[m][0] - fi.opamp_voltage[m][1]) + (1 << 19))/2;
+	scaled_voltage[m][0] = (N19*(fi.opamp_voltage[m][0] - fi.opamp_voltage[m][1]) + (1 << 19))/(2*(1 << 3));
 	scaled_voltage[m][1] = N19*fi.opamp_voltage[m][0];
       }
 
@@ -316,7 +316,7 @@ Filter::Filter()
       mf.vc_max = (int)(N19*(fi.opamp_voltage[fi.opamp_voltage_size - 1][0] - fi.opamp_voltage[fi.opamp_voltage_size - 1][1]));
 
       interpolate(scaled_voltage, scaled_voltage + fi.opamp_voltage_size - 1,
-		  PointPlotter<int>(mf.opamp), 1.0);
+		  PointPlotter<int>(mf.opamp_rev), 1.0);
 
       // DAC table.
       int bits = 11;

--- a/jni/VICEPlugin/vice/resid/filter.h
+++ b/jni/VICEPlugin/vice/resid/filter.h
@@ -417,9 +417,6 @@ protected:
   reg8 sum;
   reg8 mix;
 
-  // Voice scale and DC offset.
-  // FIXME:
- public:
   // State of filter.
   int Vhp; // highpass
   int Vbp; // bandpass
@@ -453,14 +450,16 @@ protected:
     int vc_min;
     int vc_max;
 
-    // Op-amp transfer function.
-    int opamp[1 << 19];
+    // Reverse op-amp transfer function.
+    int opamp_rev[1 << 16];
     // Lookup tables for gain and summer op-amps in output stage / filter.
     unsigned short summer[summer_offset<5>::value];
     unsigned short gain[16][1 << 16];
     unsigned short mixer[mixer_offset<8>::value];
     // Cutoff frequency DAC output voltage table. FC is an 11 bit register.
     unsigned int f0_dac[1 << 11];
+    // Op-amp transfer function.
+    int opamp[1 << 19];
   } model_filter_t;
 
   int solve_gain(int n, int vi_t, int& x, model_filter_t& mf);
@@ -1439,7 +1438,7 @@ int Filter::solve_integrate(int dt, int vi_n, int& x, int& vc,
   int n_snake = mf.n_snake;  // Scaled by (1/m)*2^19 (fits in 12 bits)
 
   // VCR gate voltage.
-  // Vddt - sqrt(Vddt*(Vddt - Vw - Vi) + (Vw*Vw + Vi*Vi)/2)
+  // Vg = Vddt - sqrt(Vddt*(Vddt - Vw - Vi) + (Vw*Vw + Vi*Vi)/2)
   // Vth could be included in the table lookup by using different tables
   // for the 6581 and the 8580.
   int Vg = Vddt - sqrt_table[(Vw_term + (vi >> 4)*(((vi >> 1) - Vddt) >> 4)) >> 14];
@@ -1510,7 +1509,7 @@ int Filter::solve_integrate(int dt, int vi_n, int& x, int& vc,
   }
 
   // vx = g(vc)
-  x = mf.opamp[(vc + (1 << 19)) >> 1];
+  x = mf.opamp_rev[(vc + (1 << 19)) >> 4];
 
   // Return vo.
   return (x - vc) - mf.vo_T19;

--- a/jni/VICEPlugin/vice/resid/sid.h
+++ b/jni/VICEPlugin/vice/resid/sid.h
@@ -93,9 +93,7 @@ public:
   // 16-bit output (AUDIO OUT).
   short output();
 
-  //FIXME:
-  //protected:
-public:
+ protected:
   static double I0(double x);
   RESID_INLINE int clock_fast(cycle_count& delta_t, short* buf, int n,
 			      int interleave);


### PR DESCRIPTION
Dag Lem cut down the size of the integrator's table by factor of 16 by my urging.

I am seeing significantly faster performance now, cpu usage seems to rarely go over 70 % using the "interpolating" mode, which makes this mode very usable! In the past, I've seen highly variable cpu speed results, which puzzled me. I'm hoping that this version is finally consistently fast. I have not touched build options, these are pretty much exactly as you left them.

Please merge these changes, and re-test. I am hoping that we are approaching something that is genuinely useful for a lot of devices now. Perhaps soon to the point that sidplay2 could be truly dispensed with?
