### PR TITLE
sort RSN subfiles before adding to handler list

### DIFF
--- a/src/com/ssb/droidsound/plugins/RSNPlugin.java
+++ b/src/com/ssb/droidsound/plugins/RSNPlugin.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -98,6 +99,7 @@ public class RSNPlugin extends DroidSoundPlugin {
 		targetFile = FileUtils.getTempDir();//fs.getFile().getParentFile();
 		rarFile.extractTo(targetFile.getPath());		
 		File [] files = targetFile.listFiles();
+        Arrays.sort(files);
 		handlers = new ArrayList<SongHandler>();
 		for(File f : files) {
 			int dot = f.getName().lastIndexOf('.');


### PR DESCRIPTION
A quick fix to sort files extracted from a .rsn by path, generally results in the right behavior for sets from snesmusic.
